### PR TITLE
Update pingid.py to handle application/octet-stream response

### DIFF
--- a/pingid.py
+++ b/pingid.py
@@ -72,7 +72,11 @@ class PingIDDriver:
         if self.verbose:
             print('{0}Response Payload{0}\n{1}\n'.format('='*20, r.content))
 
-        extracted_response = jwt.decode(r.content, key, algorithms=['HS256'])
+        if r.headers['content-type'] == 'application/octet-stream':
+            extracted_response = r.text
+
+        else:
+            extracted_response = jwt.decode(r.content, key, algorithms=['HS256'])
 
         if self.verbose:
             print('{0}Response{0}\n{1}\n'.format('='*20, json.dumps(extracted_response, indent=2)))


### PR DESCRIPTION
When calling 'rest/4/getorgreport/do' endpoint, the content-type of the response is 'application/octet-stream', not 'application/json', so the jwt.decode() fails. This update will check the headers for content-type, and if it is 'application/octet-stream' it will set the extracted_response to r.text, otherwise it will set extracted response to jwt.decode(r.content, key, algorithms=['HS256']) like it currently does.